### PR TITLE
Fixes for issues generating distribution tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ test-results/
 /test-results/
 /src/Clients/MainApp.UnitTest/test-results/
 /src/Extensions/Exporters/FSpotExporters.UnitTests/bin/
+f-spot*.tar.gz
+f-spot*.tar.bz2
+f-spot*.zip

--- a/build/m4/f-spot/dbus.m4
+++ b/build/m4/f-spot/dbus.m4
@@ -1,9 +1,9 @@
 AC_DEFUN([FSPOT_CHECK_DBUS_SHARP],
 [
-        PKG_CHECK_MODULES(DBUS_SHARP_GLIB, dbus-sharp-glib-1.0 >= 0.5)
+        PKG_CHECK_MODULES(DBUS_SHARP_GLIB, dbus-sharp-glib-2.0 >= 0.5)
         AC_SUBST(DBUS_SHARP_GLIB_LIBS)
 
-        PKG_CHECK_MODULES(DBUS_SHARP, dbus-sharp-1.0 >= 0.7)
+        PKG_CHECK_MODULES(DBUS_SHARP, dbus-sharp-2.0 >= 0.7)
         AC_SUBST(DBUS_SHARP_LIBS)
 ])
 

--- a/build/xbuild.include
+++ b/build/xbuild.include
@@ -58,6 +58,7 @@ ALL_FILES:=	$(EXTS) \
 		$(addprefix */*/*/,$(EXTS))	\
 		$(addprefix */*/*/*/,$(EXTS))	\
 		$(addprefix */*/*/*/*/,$(EXTS))	\
+                $(addprefix */*/*/*/*/*/,$(EXTS)) \
 		$(wildcard icons/*)		\
 		$(wildcard templates/*)
 

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,5 +1,11 @@
 SUBDIRS = desktop-files
 
+$(top_srcdir)/build/addin-xml-string-extractor.exe:
+	@pushd $(top_srcdir)/build;
+	make addin-xml-string-extractor.exe
+	popd;
+
+
 # Generate a fake source file containing strings for
 # translation that are found in our .addin.xml files
 ADDIN_XML_FILES = $(shell find $(top_srcdir)/src -name \*.addin.xml | grep -v /obj/)

--- a/src/Clients/MainApp/Makefile.am
+++ b/src/Clients/MainApp/Makefile.am
@@ -6,3 +6,25 @@ include $(top_srcdir)/build/xbuild.include
 bin_SCRIPTS = f-spot
 EXTRA_DIST += f-spot.exe.config
 module_SCRIPTS += f-spot.exe.config
+
+RESOURCES =  \
+	ui/color_editor_prefs_window.ui  \
+	ui/import.ui \
+	ui/mail_dialog.ui \
+	ui/main_window.ui \
+	ui/single_view.ui  \
+	ui/tag_selection_dialog.ui \
+	ui/version_name_dialog.ui \
+	ui/viewer_preferences.ui \
+	FSpot.UI.Dialog/ui/EditTagDialog.ui \
+	FSpot.UI.Dialog/ui/LastImportRollFilterDialog.ui \
+	FSpot.UI.Dialog/ui/PreferenceDialog.ui \
+	FSpot.UI.Dialog/ui/SelectionRatioDialog.ui \
+	FSpot.UI.Dialog/ui/DateRangeDialog.ui \
+	FSpot.UI.Dialog/ui/RepairDialog.ui \
+	FSpot.UI.Dialog/ui/CreateTagDialog.ui \
+	FSpot.UI.Dialog/ui/AdjustTimeDialog.ui \
+	FSpot.UI.Dialog/ui/RatingFilterDialog.ui \
+	FSpot.UI.Dialog/ui/EditTagIconDialog.ui
+
+

--- a/src/Core/FSpot.Platform/FSpot.Platform.csproj
+++ b/src/Core/FSpot.Platform/FSpot.Platform.csproj
@@ -42,11 +42,11 @@
       <Package>gconf-sharp-2.0</Package>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="dbus-sharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=5675b0c3093115b5">
-      <Package>dbus-sharp-1.0</Package>
+    <Reference Include="dbus-sharp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=5675b0c3093115b5">
+      <Package>dbus-sharp-2.0</Package>
     </Reference>
-    <Reference Include="dbus-sharp-glib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=5675b0c3093115b5">
-      <Package>dbus-sharp-glib-1.0</Package>
+    <Reference Include="dbus-sharp-glib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=5675b0c3093115b5">
+      <Package>dbus-sharp-glib-2.0</Package>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Core/Makefile.am
+++ b/src/Core/Makefile.am
@@ -1,3 +1,9 @@
+LINK =
+include $(top_srcdir)/build/build.mk
+
+include $(top_srcdir)/build/xbuild.include
+
+
 SUBDIRS = \
 		FSpot.Bling \
 		FSpot.Cms \
@@ -7,3 +13,10 @@ SUBDIRS = \
 		FSpot.Query \
 		FSpot.Gui \
 		FSpot.Platform
+
+RESOURCES = \
+		FSpot.Core.UnitTest/TestData/taglib-sample.xmp \
+		FSpot.Core.UnitTest/TestData/taglib-sample-broken.xmp \
+		FSpot.Core.UnitTest/TestData/taglib-sample.jpg \
+		FSpot.Core.UnitTest/TestData/taglib-sample-broken.jpg
+		

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,9 +4,7 @@ EXTRA_DIST = \
 	data/f-spot-0.6.1.5.db \
 	data/f-spot-0.6.2.db \
 	data/f-spot-0.7.0-17.2.db \
-	data/f-spot-0.7.0-18.0.db \
-	data/taglib-sample.jpg \
-	data/taglib-sample.xmp
+	data/f-spot-0.7.0-18.0.db
 
 if ENABLE_TESTS
 


### PR DESCRIPTION
Fixes to ensure that 'make dist' puts all of the files required for a successful build into the tarball.

Also, bump D-Bus and D-Bus GLib versions to 2.0 and lower minimum Mono version to 3.2 (for building on Debian Jessie / Sid).

Thanks.