### PR TITLE
Fix Hyena exception on first start of f-spot when no photos.db exists.

### DIFF
--- a/src/Clients/MainApp/FSpot/MetaStore.cs
+++ b/src/Clients/MainApp/FSpot/MetaStore.cs
@@ -97,12 +97,6 @@ namespace FSpot {
     	{
     		Create (version, Defines.VERSION);
     		Create (db_version, (is_new) ? FSpot.Database.Updater.LatestVersion.ToString () : "0");
-    
-    		// Get the hidden tag id, if it exists
-    		try {
-    			string id = Database.Query<string> ("SELECT id FROM tags WHERE name = 'Hidden'");
-    			Create (hidden, id);
-    		} catch (Exception) {}
     	}
     
     	private void LoadAllItems ()


### PR DESCRIPTION
The removed code will always cause an exception as no tags table exists
at this point in time. The hidden tag is created later in the startup
sequence by TagStore class.