### PR TITLE
Fix Hyena exception on first start of f-spot when no photos.db exists.

### DIFF
--- a/src/Clients/MainApp/FSpot/MetaStore.cs
+++ b/src/Clients/MainApp/FSpot/MetaStore.cs
@@ -99,10 +99,11 @@ namespace FSpot {
     		Create (db_version, (is_new) ? FSpot.Database.Updater.LatestVersion.ToString () : "0");
     
     		// Get the hidden tag id, if it exists
-    		try {
+		string table = Database.Query<string> ("SELECT name FROM sqlite_master WHERE type='table' AND name='tags'");
+		if (!string.IsNullOrEmpty(table)) {
     			string id = Database.Query<string> ("SELECT id FROM tags WHERE name = 'Hidden'");
     			Create (hidden, id);
-    		} catch (Exception) {}
+		}
     	}
     
     	private void LoadAllItems ()


### PR DESCRIPTION
For newly created databases the code surrounded by the try/catch will
always cause an exception as no tags table exists at this point in
time. The hidden tag is created later in the startup sequence by
TagStore class.

The meta table was introduced between versions 0.1.8 and 0.2.0. So for
*very* old databases the meta table needs to be created from scratch.
In this case the code is required to also create the entry for the
hidden tag.

We distinguish between these cases by checking for the existence of
the tags table and therefore remove the exception.