### PR TITLE
Remove dependancy on gnome-desktop

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,6 @@ fi
 
 dnl --- Required libraries
 
-LIBGNOMEDESKTOP_REQUIRED=2.17
 GIO_REQUIRED=2.22.0
 GTKSHARPBEANS_REQUIRED=2.13.92
 GTK_REQUIRED=2.14
@@ -137,7 +136,7 @@ MONO_CAIRO_REQUIRED=1.2.5
 CAIRO_REQUIRED=1.4.0
 LCMS2_REQUIRED=2.4
 
-PKG_CHECK_MODULES(F, gnome-desktop-2.0 >= $LIBGNOMEDESKTOP_REQUIRED gtk+-2.0 >= $GTK_REQUIRED mono-cairo >= $MONO_CAIRO_REQUIRED cairo >= $CAIRO_REQUIRED)
+PKG_CHECK_MODULES(F, gtk+-2.0 >= $GTK_REQUIRED mono-cairo >= $MONO_CAIRO_REQUIRED cairo >= $CAIRO_REQUIRED)
 AC_SUBST(F_CFLAGS)
 AC_SUBST(F_LIBS)
 
@@ -308,6 +307,7 @@ lib/Hyena/Hyena.Gui/Makefile
 lib/Hyena/Hyena/Makefile
 lib/Hyena/Makefile
 lib/libfspot/Makefile
+lib/libgnome-thumbnail-pixbuf-utils/Makefile
 lib/Makefile
 
 src/AssemblyInfo.cs

--- a/icons/Makefile.am
+++ b/icons/Makefile.am
@@ -84,7 +84,8 @@ theme_icons = 					\
 	status,mode-browse-32.png		\
 	status,mode-image-edit-16.png		\
 	status,mode-image-edit-22.png		\
-	status,mode-image-edit-24.png		
+	status,mode-image-edit-24.png		\
+	status,f-spot-question-mark.png	
 
 install_icon_exec = $(top_srcdir)/icon-theme-installer \
 	-t "$(theme)" \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,4 +1,5 @@
 # Note the list below is sorted by alphabet. Dpap-sharp isn't built.
 SUBDIRS = \
 	Hyena \
-	libfspot
+	libfspot \
+	libgnome-thumbnail-pixbuf-utils 

--- a/lib/libfspot/Makefile.am
+++ b/lib/libfspot/Makefile.am
@@ -1,4 +1,4 @@
-INCLUDES =							\
+AM_CPPFLAGS =							\
 	-I $(top_srcdir) -I $(top_srcdir)/lib/		\
 	-DLIBEOG_ETTORE_CHANGES=1				\
         -DG_LOG_DOMAIN=\"libf\"					\

--- a/lib/libgnome-thumbnail-pixbuf-utils/Makefile.am
+++ b/lib/libgnome-thumbnail-pixbuf-utils/Makefile.am
@@ -1,0 +1,20 @@
+AM_CPPFLAGS =                                                      \
+        -I $(top_srcdir) -I $(top_srcdir)/lib/          \
+        -DLIBEOG_ETTORE_CHANGES=1                               \
+        -DG_LOG_DOMAIN=\"libf\"                                 \
+        -DG_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED         \
+        -DGDK_DISABLE_DEPRECATED -DGNOME_DISABLE_DEPRECATED     \
+        -DG_DISABLE_SINGLE_INCLUDES                             \
+        -DGDK_PIXBUF_DISABLE_SINGLE_INCLUDES                    \
+        -DGTK_DISABLE_SINGLE_INCLUDES                           \
+        $(F_CFLAGS)                                             \
+        $(LCMS_CFLAGS)                                          \
+        $(WERROR)
+
+
+fspotlibdir = $(libdir)/f-spot
+fspotlib_LTLIBRARIES = libgnomethumbnailpixbufutils.la
+
+libgnomethumbnailpixbufutils_la_SOURCES =                           \
+        gnome-thumbnail-pixbuf-utils.c
+

--- a/lib/libgnome-thumbnail-pixbuf-utils/gnome-thumbnail-pixbuf-utils.c
+++ b/lib/libgnome-thumbnail-pixbuf-utils/gnome-thumbnail-pixbuf-utils.c
@@ -1,0 +1,172 @@
+/*
+ * gnome-thumbnail-pixbuf-utils.c: Utilities for handling pixbufs when thumbnailing
+ *
+ * Copyright (C) 2002 Red Hat, Inc.
+ *
+ * This file is part of the Gnome Library.
+ *
+ * The Gnome Library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * The Gnome Library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with the Gnome Library; see the file COPYING.LIB.  If not,
+ * write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ *
+ * Author: Alexander Larsson <alexl@redhat.com>
+ */
+
+#include <config.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <glib.h>
+
+//#define GNOME_DESKTOP_USE_UNSTABLE_API
+#include <gdk-pixbuf/gdk-pixbuf.h>
+
+#define LOAD_BUFFER_SIZE 65536
+
+/**
+ * gnome_desktop_thumbnail_scale_down_pixbuf:
+ * @pixbuf: a #GdkPixbuf
+ * @dest_width: the desired new width
+ * @dest_height: the desired new height
+ *
+ * Scales the pixbuf to the desired size. This function
+ * is a lot faster than gdk-pixbuf when scaling down by
+ * large amounts.
+ *
+ * Return value: (transfer full): a scaled pixbuf
+ * 
+ * Since: 2.2
+ **/
+GdkPixbuf *
+gnome_desktop_thumbnail_scale_down_pixbuf (GdkPixbuf *pixbuf,
+					   int dest_width,
+					   int dest_height)
+{
+	int source_width, source_height;
+	int s_x1, s_y1, s_x2, s_y2;
+	int s_xfrac, s_yfrac;
+	int dx, dx_frac, dy, dy_frac;
+	div_t ddx, ddy;
+	int x, y;
+	int r, g, b, a;
+	int n_pixels;
+	gboolean has_alpha;
+	guchar *dest, *src, *xsrc, *src_pixels;
+	GdkPixbuf *dest_pixbuf;
+	int pixel_stride;
+	int source_rowstride, dest_rowstride;
+
+	if (dest_width == 0 || dest_height == 0) {
+		return NULL;
+	}
+	
+	source_width = gdk_pixbuf_get_width (pixbuf);
+	source_height = gdk_pixbuf_get_height (pixbuf);
+
+	g_assert (source_width >= dest_width);
+	g_assert (source_height >= dest_height);
+
+	ddx = div (source_width, dest_width);
+	dx = ddx.quot;
+	dx_frac = ddx.rem;
+	
+	ddy = div (source_height, dest_height);
+	dy = ddy.quot;
+	dy_frac = ddy.rem;
+
+	has_alpha = gdk_pixbuf_get_has_alpha (pixbuf);
+	source_rowstride = gdk_pixbuf_get_rowstride (pixbuf);
+	src_pixels = gdk_pixbuf_get_pixels (pixbuf);
+
+	dest_pixbuf = gdk_pixbuf_new (GDK_COLORSPACE_RGB, has_alpha, 8,
+				      dest_width, dest_height);
+	dest = gdk_pixbuf_get_pixels (dest_pixbuf);
+	dest_rowstride = gdk_pixbuf_get_rowstride (dest_pixbuf);
+
+	pixel_stride = (has_alpha)?4:3;
+	
+	s_y1 = 0;
+	s_yfrac = -dest_height/2;
+	while (s_y1 < source_height) {
+		s_y2 = s_y1 + dy;
+		s_yfrac += dy_frac;
+		if (s_yfrac > 0) {
+			s_y2++;
+			s_yfrac -= dest_height;
+		}
+
+		s_x1 = 0;
+		s_xfrac = -dest_width/2;
+		while (s_x1 < source_width) {
+			s_x2 = s_x1 + dx;
+			s_xfrac += dx_frac;
+			if (s_xfrac > 0) {
+				s_x2++;
+				s_xfrac -= dest_width;
+			}
+
+			/* Average block of [x1,x2[ x [y1,y2[ and store in dest */
+			r = g = b = a = 0;
+			n_pixels = 0;
+
+			src = src_pixels + s_y1 * source_rowstride + s_x1 * pixel_stride;
+			for (y = s_y1; y < s_y2; y++) {
+				xsrc = src;
+				if (has_alpha) {
+					for (x = 0; x < s_x2-s_x1; x++) {
+						n_pixels++;
+						
+						r += xsrc[3] * xsrc[0];
+						g += xsrc[3] * xsrc[1];
+						b += xsrc[3] * xsrc[2];
+						a += xsrc[3];
+						xsrc += 4;
+					}
+				} else {
+					for (x = 0; x < s_x2-s_x1; x++) {
+						n_pixels++;
+						r += *xsrc++;
+						g += *xsrc++;
+						b += *xsrc++;
+					}
+				}
+				src += source_rowstride;
+			}
+			
+			if (has_alpha) {
+				if (a != 0) {
+					*dest++ = r / a;
+					*dest++ = g / a;
+					*dest++ = b / a;
+					*dest++ = a / n_pixels;
+				} else {
+					*dest++ = 0;
+					*dest++ = 0;
+					*dest++ = 0;
+					*dest++ = 0;
+				}
+			} else {
+				*dest++ = r / n_pixels;
+				*dest++ = g / n_pixels;
+				*dest++ = b / n_pixels;
+			}
+			
+			s_x1 = s_x2;
+		}
+		s_y1 = s_y2;
+		dest += dest_rowstride - dest_width * pixel_stride;
+	}
+	
+	return dest_pixbuf;
+}

--- a/src/Clients/MainApp/PixbufUtils.cs
+++ b/src/Clients/MainApp/PixbufUtils.cs
@@ -515,7 +515,7 @@ public static class PixbufUtils
 		}
 	}
 
-	[DllImport("libgnome-desktop-2-17.dll")]
+	[DllImport("libgnomethumbnailpixbufutils.dll")]
 	static extern IntPtr gnome_desktop_thumbnail_scale_down_pixbuf (IntPtr pixbuf, int dest_width, int dest_height);
 
 	public static Gdk.Pixbuf ScaleDown (Gdk.Pixbuf src, int width, int height)

--- a/src/Clients/MainApp/f-spot.exe.config.in
+++ b/src/Clients/MainApp/f-spot.exe.config.in
@@ -1,7 +1,7 @@
 <configuration>
   <dllmap dll="libfspot" target="@expanded_libdir@/f-spot/libfspot.so.0"/>
+  <dllmap dll="libgnomethumbnailpixbufutils.dll" target="@expanded_libdir@/f-spot/libgnomethumbnailpixbufutils.so.0"/>
   <dllmap dll="libgdk-2.0-0.dll" target="libgdk-x11-2.0.so.0"/>
   <dllmap dll="libgdk_pixbuf-2.0-0.dll" target="libgdk_pixbuf-2.0.so.0"/>
   <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
-  <dllmap dll="libgnome-desktop-2-17.dll" target="libgnome-desktop-2.so.17"/>
 </configuration>


### PR DESCRIPTION
Remove dependency on gnome-desktop by extracting the only function used from gnome-desktop and building it as a small library bundled with F-Spot.

gnome-desktop-2 has been removed from Debian Sid, and gnome-desktop-3 is compatible with GTK+3, whereas F-Spot master is compatible with GTK+2.

Also a commit to add a missing icon to the install.