### PR TITLE
Do not crash for missing stock icons

### DIFF
--- a/src/Core/FSpot.Core/Tag.cs
+++ b/src/Core/FSpot.Core/Tag.cs
@@ -113,7 +113,7 @@ namespace FSpot.Core
 
 					    if (Math.Max (cached_icon.Width, cached_icon.Height) <= (int)tag_icon_size)
 						    return cached_icon;
-                    } catch (Exception e) {
+                    } catch (Exception) {
                         Console.WriteLine ("missing theme icon: {0}", ThemeIconName);
                         return null;
                     }

--- a/src/Core/FSpot.Core/Tag.cs
+++ b/src/Core/FSpot.Core/Tag.cs
@@ -108,10 +108,16 @@ namespace FSpot.Core
 				if (ThemeIconName != null) { //Theme icon
 					if (cached_icon != null)
 						cached_icon.Dispose ();
-					cached_icon = GtkUtil.TryLoadIcon (Global.IconTheme, ThemeIconName, (int)tag_icon_size, (Gtk.IconLookupFlags)0);
+                    try {
+					    cached_icon = GtkUtil.TryLoadIcon (Global.IconTheme, ThemeIconName, (int)tag_icon_size, (Gtk.IconLookupFlags)0);
 
-					if (Math.Max (cached_icon.Width, cached_icon.Height) <= (int)tag_icon_size)
-						return cached_icon;
+					    if (Math.Max (cached_icon.Width, cached_icon.Height) <= (int)tag_icon_size)
+						    return cached_icon;
+                    } catch (Exception e) {
+                        Console.WriteLine ("missing theme icon: {0}", ThemeIconName);
+                        return null;
+                    }
+                        
 				}
 				if (Icon == null)
 					return null;

--- a/src/Core/FSpot.Core/Tag.cs
+++ b/src/Core/FSpot.Core/Tag.cs
@@ -108,16 +108,15 @@ namespace FSpot.Core
 				if (ThemeIconName != null) { //Theme icon
 					if (cached_icon != null)
 						cached_icon.Dispose ();
-                    try {
-					    cached_icon = GtkUtil.TryLoadIcon (Global.IconTheme, ThemeIconName, (int)tag_icon_size, (Gtk.IconLookupFlags)0);
+					try {
+						cached_icon = GtkUtil.TryLoadIcon (Global.IconTheme, ThemeIconName, (int)tag_icon_size, (Gtk.IconLookupFlags)0);
 
-					    if (Math.Max (cached_icon.Width, cached_icon.Height) <= (int)tag_icon_size)
-						    return cached_icon;
-                    } catch (Exception) {
-                        Console.WriteLine ("missing theme icon: {0}", ThemeIconName);
-                        return null;
-                    }
-                        
+						if (Math.Max (cached_icon.Width, cached_icon.Height) <= (int)tag_icon_size)
+							return cached_icon;
+					} catch (Exception) {
+						Console.WriteLine ("missing theme icon: {0}", ThemeIconName);
+						return null;
+					}
 				}
 				if (Icon == null)
 					return null;


### PR DESCRIPTION
While testing a newly-built f-spot with an old photos.db I hit upon a few other crashes due to missing stock icons. As this is probably not an uncommon situation and certainly not something the program should crash on this change turns the crash into a warning about the missing stock icon, returning an empty icon.

Example output:
```
missing theme icon: emblem-new
missing theme icon: emblem-web
missing theme icon: emblem-web
missing theme icon: emblem-urgent
missing theme icon: emblem-urgent
missing theme icon: emblem-system
missing theme icon: emblem-system
missing theme icon: emblem-new
missing theme icon: emblem-new
missing theme icon: emblem-system
missing theme icon: emblem-system
missing theme icon: emblem-system
missing theme icon: emblem-system
```

This change makes f-spot more robust against misconfigured or incomplete icon themes.