### PR TITLE
Explicitly cast id to uint to match ...Job constructors

### DIFF
--- a/src/Clients/MainApp/FSpot/JobStore.cs
+++ b/src/Clients/MainApp/FSpot/JobStore.cs
@@ -156,7 +156,7 @@ namespace FSpot {
     						DateTimeUtil.FromDateTime (run_at),
     						Convert.ToInt32 (job_priority)));
     
-                    Job job = (Job)Activator.CreateInstance (job_type, id, job_options, run_at, job_priority, true);
+			Job job = (Job)Activator.CreateInstance (job_type, (uint) id, job_options, run_at, job_priority, true);
     
     		AddToCache (job);
     		job.Finished += HandleRemoveJob;


### PR DESCRIPTION
This avoids a crash on import due to _Constructor on type 'FSpot.Jobs.SyncMetadataJob' not found_. All (two) ...Job constructors expect _id_ to be _uint_, but the value passed was _long_.