### PR TITLE
Fix crash when warning dialog regarding removal of photos was opened.

### DIFF
--- a/src/Clients/MainApp/FSpot.UI.Dialog/ImportDialog.cs
+++ b/src/Clients/MainApp/FSpot.UI.Dialog/ImportDialog.cs
@@ -213,10 +213,7 @@ namespace FSpot.UI.Dialog
                 var dialog = new MessageDialog (this, DialogFlags.Modal, MessageType.Warning, ButtonsType.Ok, true,
                         Catalog.GetString ("Checking this box will remove the imported photos from the camera after the import finished successfully.\n\nIt is generally recommended to backup your photos before removing them from the camera. <b>Use this option at your own risk!</b>"));
                 dialog.Title = Catalog.GetString ("Warning");
-                dialog.Response += (s, arg) => {
-                    dialog.Destroy ();
-                    Controller = null;
-                };
+                dialog.Response += (s, arg) => dialog.Destroy ();
                 dialog.Run ();
             };
             Response += (o, args) => {


### PR DESCRIPTION
Crash happend when after closing the warning dialog a check box in the
import dialog was checked/unchecked.