### PR TITLE
Missing dll map and taglib-sharp

### DIFF
--- a/src/Core/FSpot.Imaging/FSpot.Imaging.csproj
+++ b/src/Core/FSpot.Imaging/FSpot.Imaging.csproj
@@ -81,4 +81,9 @@
       <Name>FSpot.Utils</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="FSpot.Imaging.dll.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/Core/FSpot.Imaging/FSpot.Imaging.dll.config
+++ b/src/Core/FSpot.Imaging/FSpot.Imaging.dll.config
@@ -1,0 +1,3 @@
+<configuration>
+  <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
+</configuration>


### PR DESCRIPTION
Hello, I've been updating the Debian package and have noticed the following things:

1) FSpot.Imaging.dll is missing a config file with a DLL map.

2) taglib-sharp was pointing to an old commit which had a broken submodule (raw-samples). This prevented git buildpackage --git-submodules from working (as it's recursive).

As I don't think these issues are Debian specific, I thought you might like to merge them.
