### PR TITLE
fix for bug #633188

### DIFF
--- a/src/Clients/MainApp/FSpot/PrintOperation.cs
+++ b/src/Clients/MainApp/FSpot/PrintOperation.cs
@@ -124,8 +124,8 @@ namespace FSpot
 			double w = context.Width / ppx;
 			double h = context.Height / ppy;
 
-			// compute picture size using 4800DPI
-			double mx=(w / 25.4) * 4800, my=(h / 25.4) * 4800;
+			// compute picture size
+			double mx=(w / 25.4) * context.DpiX, my=(h / 25.4) * context.DpiY;
 
 			for (int x = 0; x <= ppx; x++) {
 				for (int y = 0; y <= ppy; y++) {

--- a/src/Clients/MainApp/FSpot/PrintOperation.cs
+++ b/src/Clients/MainApp/FSpot/PrintOperation.cs
@@ -37,6 +37,7 @@ using Mono.Unix;
 using FSpot.Core;
 using FSpot.Widgets;
 using FSpot.Imaging;
+using FSpot.Utils;
 
 using Hyena;
 
@@ -267,13 +268,9 @@ namespace FSpot
 			cr.Restore ();
 		}
 
-		//FIXME: f_pixbuf_from_cairo_surface is missing from libfspot
-		[DllImport("libfspot")]
-		static extern IntPtr f_pixbuf_from_cairo_surface (IntPtr handle);
-
 		static Gdk.Pixbuf CreatePixbuf (Surface s)
 		{
-			IntPtr result = f_pixbuf_from_cairo_surface (s.Handle);
+			IntPtr result = CairoUtils.PixbufFromSurface(s);
 			return (Gdk.Pixbuf) GLib.Object.GetObject (result, true);
 		}
 	}

--- a/src/Clients/MainApp/FSpot/PrintOperation.cs
+++ b/src/Clients/MainApp/FSpot/PrintOperation.cs
@@ -139,6 +139,10 @@ namespace FSpot
 						Gdk.Pixbuf pixbuf;
 						try {
 							pixbuf = img.Load ((int) mx, (int) my);
+							if (pixbuf == null) {
+								Log.Error ("Not enough memory for printing " + selected_photos [p_index].DefaultVersion.Uri);
+								continue;
+							}
 							Cms.Profile printer_profile;
 							if (ColorManagement.Profiles.TryGetValue (Preferences.Get<string> (Preferences.COLOR_MANAGEMENT_OUTPUT_PROFILE), out printer_profile))
 								ColorManagement.ApplyProfile (pixbuf, img.GetProfile (), printer_profile);
@@ -149,7 +153,7 @@ namespace FSpot
 										      PixbufUtils.ErrorPixbuf.Width,
 										      PixbufUtils.ErrorPixbuf.Height);
 						}
-						//Gdk.Pixbuf pixbuf = img.Load (100, 100);
+
 						bool rotated = false;
 						if (Math.Sign ((double)pixbuf.Width/pixbuf.Height - 1.0) != Math.Sign (w/h - 1.0)) {
 							Gdk.Pixbuf d_pixbuf = pixbuf.RotateSimple (Gdk.PixbufRotation.Counterclockwise);

--- a/src/Clients/MainApp/FSpot/PrintOperation.cs
+++ b/src/Clients/MainApp/FSpot/PrintOperation.cs
@@ -268,10 +268,9 @@ namespace FSpot
 			cr.Restore ();
 		}
 
-		static Gdk.Pixbuf CreatePixbuf (Surface s)
+		static Gdk.Pixbuf CreatePixbuf (ImageSurface s)
 		{
-			IntPtr result = CairoUtils.PixbufFromSurface(s);
-			return (Gdk.Pixbuf) GLib.Object.GetObject (result, true);
+			return CairoUtils.PixbufFromSurface(s);
 		}
 	}
 }

--- a/src/Core/FSpot.Utils/CairoUtils.cs
+++ b/src/Core/FSpot.Utils/CairoUtils.cs
@@ -45,5 +45,67 @@ namespace FSpot.Utils
 							       width, height);
 			return surface;
 		}
+
+		public static IntPtr PixbufFromSurface(Surface source)
+		{
+			int width = cairo_image_surface_get_width (source.Handle);
+			int height = cairo_image_surface_get_height (source.Handle);
+			return IntPtr.Zero;
+			/*
+			GdkPixbuf *pixbuf = gdk_pixbuf_new(GDK_COLORSPACE_RGB,
+							   TRUE,
+						           8,
+						           width,
+						           height);
+
+			guchar *gdk_pixels = gdk_pixbuf_get_pixels (pixbuf);
+			int gdk_rowstride = gdk_pixbuf_get_rowstride (pixbuf);
+			int n_channels = gdk_pixbuf_get_n_channels (pixbuf);
+			cairo_format_t format;
+			cairo_surface_t *surface;
+			cairo_t *ctx;
+			static const cairo_user_data_key_t key;
+			int j;
+		
+			format = f_image_surface_get_format (source);
+			surface = cairo_image_surface_create_for_data (gdk_pixels,
+								 format,
+								 width, height, gdk_rowstride);
+			ctx = cairo_create (surface);
+			cairo_set_source_surface (ctx, source, 0, 0);
+			if (format == CAIRO_FORMAT_ARGB32)
+				cairo_mask_surface (ctx, source, 0, 0);
+			else
+				cairo_paint (ctx);
+
+			for (j = height; j; j--)
+			{
+				guchar *p = gdk_pixels;
+				guchar *end = p + 4 * width;
+				guchar tmp;
+
+				while (p < end)
+				{
+					tmp = p[0];
+			#if G_BYTE_ORDER == G_LITTLE_ENDIAN
+					p[0] = p[2];
+					p[2] = tmp;
+			#else
+					p[0] = p[1];
+					p[1] = p[2];
+					p[2] = p[3];
+					p[3] = tmp;
+			#endif
+					p += 4;
+				}
+		
+			gdk_pixels += gdk_rowstride;
+			}
+
+			cairo_destroy (ctx);
+			cairo_surface_destroy (surface);
+			return pixbuf;
+*/
+		}
 	}
 }

--- a/src/Core/FSpot.Utils/CairoUtils.cs
+++ b/src/Core/FSpot.Utils/CairoUtils.cs
@@ -94,35 +94,6 @@ namespace FSpot.Utils
 			surface.Destroy();
 			Pixbuf pixbuf = new Pixbuf(gdkPixels, Colorspace.Rgb, true, 8, width, height);
 			return pixbuf;
-			/*
-			for (j = height; j; j--)
-			{
-				guchar *p = gdk_pixels;
-				guchar *end = p + 4 * width;
-				guchar tmp;
-
-				while (p < end)
-				{
-					tmp = p[0];
-			#if G_BYTE_ORDER == G_LITTLE_ENDIAN
-					p[0] = p[2];
-					p[2] = tmp;
-			#else
-					p[0] = p[1];
-					p[1] = p[2];
-					p[2] = p[3];
-					p[3] = tmp;
-			#endif
-					p += 4;
-				}
-		
-			gdk_pixels += gdk_rowstride;
-			}
-
-			cairo_destroy (ctx);
-			cairo_surface_destroy (surface);
-			return pixbuf;
-*/
 		}
 	}
 }

--- a/src/Core/FSpot.Utils/CairoUtils.cs
+++ b/src/Core/FSpot.Utils/CairoUtils.cs
@@ -52,26 +52,23 @@ namespace FSpot.Utils
 		{
 			int width = source.Width;
 			int height = source.Height;
-			Pixbuf pixbuf = new Pixbuf(Colorspace.Rgb, true, 8, width, height);
-                        byte []gdkPixels = new byte[width*height];
-			Marshal.Copy(pixbuf.Pixels, gdkPixels, 0, width*height);
-			int gdkRowstride = pixbuf.Rowstride;
-			int nChannels = pixbuf.NChannels;
-			int j;
+                        byte []gdkPixels = new byte[width*height*4];
 
 			Format format = source.Format;
 		
-			Surface surface = new ImageSurface(gdkPixels, format, width, height, gdkRowstride);
+			Surface surface = new ImageSurface(gdkPixels, format, width, height, 4*width);
 			Context ctx = new Context(surface);
 			ctx.SetSourceSurface(source, 0, 0);
+
 			if (format == Format.ARGB32)
 				ctx.MaskSurface(source, 0, 0);
 			else
 				ctx.Paint();
 
+			int j;
 			for (j=height; j > 0 ;j--)
 			{
-				int p = (height-j)*gdkRowstride;
+				int p = (height-j)*4*width;
 				int end = p + 4*width;
 				byte tmp;
 
@@ -95,6 +92,7 @@ namespace FSpot.Utils
 			}
 
 			surface.Destroy();
+			Pixbuf pixbuf = new Pixbuf(gdkPixels, Colorspace.Rgb, true, 8, width, height);
 			return pixbuf;
 			/*
 			for (j = height; j; j--)

--- a/src/Core/FSpot.Utils/CairoUtils.cs
+++ b/src/Core/FSpot.Utils/CairoUtils.cs
@@ -92,7 +92,7 @@ namespace FSpot.Utils
 			}
 
 			surface.Destroy();
-			Pixbuf pixbuf = new Pixbuf(gdkPixels, Colorspace.Rgb, true, 8, width, height);
+			Pixbuf pixbuf = new Pixbuf(gdkPixels, Colorspace.Rgb, true, 8, width, height, 4*width);
 			return pixbuf;
 		}
 	}


### PR DESCRIPTION
f_pixbuf_from_cairo_surface was missing

I've ported the old C code in C#
CairoUtils now has PixbufFromSurface method.

the print operation is always to cause crash, but in another point.... I continue to work...