### PR TITLE
Fix icon install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ http://f-spot.org/
 
 	- liblcms 2 or later, http://www.littlecms.com/
 
-	- hicolor-icon-theme 0.10 or later, http://icon-theme.freedesktop.org/wiki/HicolorTheme
+	- hicolor-icon-theme 0.10 or later, https://www.freedesktop.org/wiki/Software/icon-theme
+
+	- gnome-icon-theme 3.12.0 or later, https://download.gnome.org/sources/gnome-icon-theme/3.12
 
 	- taglib-sharp 2.0.3.7 or later, https://github.com/mono/taglib-sharp
 

--- a/icons/Makefile.am
+++ b/icons/Makefile.am
@@ -1,8 +1,14 @@
 theme = hicolor
 themedir = $(pkgdatadir)/icons/$(theme)
-hicolordir = $(DESTDIR)$(datadir)/icons/hicolor
 
 theme_icons = 					\
+	apps,f-spot-16.png			\
+	apps,f-spot-22.png			\
+	apps,f-spot-24.png			\
+	apps,f-spot-32.png			\
+	apps,f-spot-48.png			\
+	apps,f-spot-128.png			\
+	apps,f-spot-256.png			\
 	actions,adjust-colors-16.png		\
 	actions,adjust-colors-22.png		\
 	actions,adjust-colors-24.png		\
@@ -101,30 +107,9 @@ install_icon_exec = $(top_srcdir)/icon-theme-installer \
 
 install-data-local:
 	@-$(install_icon_exec) -i $(theme_icons)
-	$(mkinstalldirs) $(hicolordir)/16x16/apps
-	$(INSTALL_DATA) $(srcdir)/f-spot-16.png $(hicolordir)/16x16/apps/f-spot.png
-	$(mkinstalldirs) $(hicolordir)/22x22/apps
-	$(INSTALL_DATA) $(srcdir)/f-spot-22.png $(hicolordir)/22x22/apps/f-spot.png
-	$(mkinstalldirs) $(hicolordir)/24x24/apps
-	$(INSTALL_DATA) $(srcdir)/f-spot-24.png $(hicolordir)/24x24/apps/f-spot.png
-	$(mkinstalldirs) $(hicolordir)/32x32/apps
-	$(INSTALL_DATA) $(srcdir)/f-spot-32.png $(hicolordir)/32x32/apps/f-spot.png
-	$(mkinstalldirs) $(hicolordir)/48x48/apps
-	$(INSTALL_DATA) $(srcdir)/f-spot-48.png $(hicolordir)/48x48/apps/f-spot.png
-	$(mkinstalldirs) $(hicolordir)/128x128/apps
-	$(INSTALL_DATA) $(srcdir)/f-spot-128.png $(hicolordir)/128x128/apps/f-spot.png
-	$(mkinstalldirs) $(hicolordir)/256x256/apps
-	$(INSTALL_DATA) $(srcdir)/f-spot-256.png $(hicolordir)/256x256/apps/f-spot.png
 
 uninstall-hook: 
 	@-$(install_icon_exec) -u $(theme_icons)
-	rm -f $(hicolordir)/16x16/apps/f-spot.png
-	rm -f $(hicolordir)/22x22/apps/f-spot.png
-	rm -f $(hicolordir)/24x24/apps/f-spot.png
-	rm -f $(hicolordir)/32x32/apps/f-spot.png
-	rm -f $(hicolordir)/48x48/apps/f-spot.png
-	rm -f $(hicolordir)/128x128/apps/f-spot.png
-	rm -f $(hicolordir)/256x256/apps/f-spot.png
 
 MAINTAINERCLEANFILES = Makefile.in
 EXTRA_DIST = $(wildcard *.png *.svg)	\


### PR DESCRIPTION
After a 'make install' the application icon of f-spot was missing as it was installed in wrong folder (share/icons instead of share/f-spot/icons). It was also missing in the icon cache as it was copied but not added to the cache, which is done by icon-theme-installer script.

Also, gnome-icon-theme is required to get all icons for buttons etc.