### PR TITLE
Linking Literal.Tag with base.tag

### DIFF
--- a/src/Clients/FSpot/FSpot.Query/Literal.cs
+++ b/src/Clients/FSpot/FSpot.Query/Literal.cs
@@ -56,7 +56,7 @@ namespace FSpot.Query
 
 		public Literal (Term parent, Tag tag, Literal after) : base (parent, after)
 		{
-			Tag = tag;
+			this.tag = tag;
 		}
 
 		static Literal ()
@@ -67,7 +67,14 @@ namespace FSpot.Query
 		#region Properties
 		public static List<Literal> FocusedLiterals { get; set; }
 
-		public Tag Tag { get; private set; }
+		public Tag Tag {
+			get {
+				return tag;
+			}
+			private set {
+				tag = value;
+			}
+		}
 
 		public override bool IsNegated {
 			get {


### PR DESCRIPTION
Abstract class `Term` implements `FindByTag()` method and assumes that the `Tag` is stored in a member called `tag`.

Child class `Literal` defines a `Tag` property that is unlinked to it's `base.tag` member.

As a result of this `FindByTag()` method fails to find the tags.

As a consequence of this bug the main app fails to show the pictures tagged as Hidden because `AndTerm` uses `FindByTag(hidden)` to add the restriction in the SQL expression.

This commit refactors `Literal.Tag` property as a wrapper of `Term.tag` member.