### PR TITLE
Resolve job types using TinyIoCContainer

### DIFF
--- a/src/Core/FSpot.Database/FSpot.Database.csproj
+++ b/src/Core/FSpot.Database/FSpot.Database.csproj
@@ -101,6 +101,7 @@
     <Compile Include="IUpdaterUI.cs" />
     <Compile Include="Jobs\CalculateHashJob.cs" />
     <Compile Include="Jobs\Job.cs" />
+    <Compile Include="Jobs\JobData.cs" />
     <Compile Include="Jobs\SyncMetadataJob.cs" />
     <Compile Include="IDb.cs" />
   </ItemGroup>

--- a/src/Core/FSpot.Database/FSpot.Database.csproj
+++ b/src/Core/FSpot.Database/FSpot.Database.csproj
@@ -100,6 +100,7 @@
     <Compile Include="PhotoEventArgs.cs" />
     <Compile Include="IUpdaterUI.cs" />
     <Compile Include="Jobs\CalculateHashJob.cs" />
+    <Compile Include="Jobs\Job.cs" />
     <Compile Include="Jobs\SyncMetadataJob.cs" />
     <Compile Include="IDb.cs" />
   </ItemGroup>

--- a/src/Core/FSpot.Database/JobStore.cs
+++ b/src/Core/FSpot.Database/JobStore.cs
@@ -40,14 +40,16 @@ namespace FSpot.Database
 {
 	public class JobStore : DbStore<Job>
 	{
+		private const string jobsTableName = "jobs";
+
 		internal static void CreateTable (FSpotDatabaseConnection database)
 		{
-			if (database.TableExists ("jobs")) {
+			if (database.TableExists (jobsTableName)) {
 				return;
 			}
 
 			database.Execute (
-				"CREATE TABLE jobs (\n" +
+				$"CREATE TABLE {jobsTableName} (\n" +
 				"  id           INTEGER PRIMARY KEY NOT NULL, \n" +
 				"  job_type     TEXT NOT NULL, \n" +
 				"  job_options  TEXT NOT NULL, \n" +
@@ -70,7 +72,7 @@ namespace FSpot.Database
 
 		private void LoadAllItems ()
 		{
-			Hyena.Data.Sqlite.IDataReader reader = Database.Query ("SELECT id, job_type, job_options, run_at, job_priority FROM jobs");
+			Hyena.Data.Sqlite.IDataReader reader = Database.Query ($"SELECT id, job_type, job_options, run_at, job_priority FROM {jobsTableName}");
 
 			Scheduler.Suspend ();
 			while (reader.Read ()) {
@@ -98,7 +100,7 @@ namespace FSpot.Database
 		{
 			long id = 0;
 			if (persistent)
-				id = Database.Execute (new HyenaSqliteCommand ("INSERT INTO jobs (job_type, job_options, run_at, job_priority) VALUES (?, ?, ?, ?)",
+				id = Database.Execute (new HyenaSqliteCommand ($"INSERT INTO {jobsTableName} (job_type, job_options, run_at, job_priority) VALUES (?, ?, ?, ?)",
 							job_type.ToString (),
 							job_options,
 							DateTimeUtil.FromDateTime (run_at),
@@ -119,7 +121,7 @@ namespace FSpot.Database
 		{
 			if (item.Persistent)
 				Database.Execute (new HyenaSqliteCommand (
-					"UPDATE jobs " +
+					$"UPDATE {jobsTableName} " +
 					"  SET job_type = ? " +
 					"  SET job_options = ? " +
 					"  SET run_at = ? " +
@@ -145,7 +147,7 @@ namespace FSpot.Database
 			RemoveFromCache (item);
 
 			if (item.Persistent)
-				Database.Execute (new HyenaSqliteCommand ("DELETE FROM jobs WHERE id = ?", item.Id));
+				Database.Execute (new HyenaSqliteCommand ($"DELETE FROM {jobsTableName} WHERE id = ?", item.Id));
 
 			EmitRemoved (item);
 		}
@@ -157,7 +159,7 @@ namespace FSpot.Database
 
 		public JobStore (IDb db, bool is_new) : base (db, true)
 		{
-			if (is_new || !Database.TableExists ("jobs")) {
+			if (is_new || !Database.TableExists (jobsTableName)) {
 				CreateTable (Database);
 			} else {
 				LoadAllItems ();

--- a/src/Core/FSpot.Database/JobStore.cs
+++ b/src/Core/FSpot.Database/JobStore.cs
@@ -34,6 +34,7 @@ using System;
 using Banshee.Kernel;
 
 using FSpot.Core;
+using FSpot.Database.Jobs;
 using FSpot.Jobs;
 
 using Hyena;
@@ -41,56 +42,6 @@ using Hyena.Data.Sqlite;
 
 namespace FSpot.Database
 {
-    public abstract class Job : DbItem, IJob
-    {
-    	public Job (IDb db, uint id, string job_options, JobPriority job_priority, DateTime run_at, bool persistent) : base (id)
-    	{
-    		JobOptions = job_options;
-    		JobPriority = job_priority;
-    		RunAt = run_at;
-    		Persistent = persistent;
-			Db = db;
-    	}
-    
-    	public string JobOptions { get; set; }
-    	internal JobPriority JobPriority { get; set; }
-    	//Not in use yet !
-    	public DateTime RunAt { get; private set; }
-    	public bool Persistent { get; private set; }
-		protected IDb Db { get; private set; }
-    
-    	public event EventHandler Finished;
-    
-    	private JobStatus status;
-    	public JobStatus Status
-    	{
-    		get { return status; }
-    		set {
-    			status = value;
-    			switch (value) {
-    			case JobStatus.Finished:
-    			case JobStatus.Failed:
-    				if (Finished != null)
-    					Finished (this, new EventArgs ());
-    				break;
-    			default:
-    				break;
-    			}
-    		}
-    	}
-    
-    	public void Run ()
-    	{
-    		Status = JobStatus.Running;
-    		if (Execute ())
-    			Status = JobStatus.Finished;
-    		else
-    			Status = JobStatus.Failed;
-    	}
-    
-    	protected abstract bool Execute ();
-    }
-
     public class JobStore : DbStore<Job> {
     
     	internal static void CreateTable (FSpotDatabaseConnection database)

--- a/src/Core/FSpot.Database/JobStore.cs
+++ b/src/Core/FSpot.Database/JobStore.cs
@@ -65,7 +65,7 @@ namespace FSpot.Database
 					Db,
 					Convert.ToUInt32 (reader ["id"]),
 					reader ["job_options"].ToString (),
-					Convert.ToInt32 (reader ["run_at"]),
+					DateTimeUtil.ToDateTime (Convert.ToInt32 (reader ["run_at"])),
 					(JobPriority)Convert.ToInt32 (reader ["job_priority"]),
 					true);
 		}

--- a/src/Core/FSpot.Database/JobStore.cs
+++ b/src/Core/FSpot.Database/JobStore.cs
@@ -60,7 +60,14 @@ namespace FSpot.Database
 
 		private Job CreateJob (Type type, uint id, string options, DateTime runAt, JobPriority priority)
 		{
-			return (Job)Activator.CreateInstance (type, Db, id, options, runAt, priority, true);
+			return (Job)Activator.CreateInstance (type, Db, new JobData
+			{
+				Id = id,
+				JobOptions = options,
+				JobPriority = priority,
+				RunAt = runAt,
+				Persistent = true
+			});
 		}
 
 		private Job LoadItem (Hyena.Data.Sqlite.IDataReader reader)

--- a/src/Core/FSpot.Database/JobStore.cs
+++ b/src/Core/FSpot.Database/JobStore.cs
@@ -30,141 +30,138 @@
 //
 
 using System;
-
 using Banshee.Kernel;
-
-using FSpot.Core;
 using FSpot.Database.Jobs;
 using FSpot.Jobs;
-
 using Hyena;
 using Hyena.Data.Sqlite;
 
 namespace FSpot.Database
 {
-    public class JobStore : DbStore<Job> {
-    
-    	internal static void CreateTable (FSpotDatabaseConnection database)
-    	{
-    		if (database.TableExists ("jobs")) {
-    			return;
-    		}
-    
-    		database.Execute (
-    			"CREATE TABLE jobs (\n" +
-    			"	id		INTEGER PRIMARY KEY NOT NULL, \n" +
-    			"	job_type	TEXT NOT NULL, \n" +
-    			"	job_options	TEXT NOT NULL, \n" +
-    			"	run_at		INTEGER, \n" +
-    			"	job_priority	INTEGER NOT NULL\n" +
-    			")");
-    	}
-    
-    	private Job LoadItem (Hyena.Data.Sqlite.IDataReader reader)
-    	{
-    		return (Job) Activator.CreateInstance (
-    				Type.GetType (reader ["job_type"].ToString ()),
-    				Db,
-    				Convert.ToUInt32 (reader["id"]),
-    				reader["job_options"].ToString (),
-    				Convert.ToInt32 (reader["run_at"]),
-    				(JobPriority) Convert.ToInt32 (reader["job_priority"]),
-    				true);
-    	}
-    
-    	private void LoadAllItems ()
-    	{
-    		Hyena.Data.Sqlite.IDataReader reader = Database.Query ("SELECT id, job_type, job_options, run_at, job_priority FROM jobs");
-    
-    		Scheduler.Suspend ();
-    		while (reader.Read ()) {
-    			Job job = LoadItem (reader);
-    			AddToCache (job);
-    			job.Finished += HandleRemoveJob;
-    			Scheduler.Schedule (job, job.JobPriority);
-    			job.Status = JobStatus.Scheduled;
-    		}
-    
-    		reader.Dispose ();
-    	}
-    
-    	public Job Create (Type job_type, string job_options)
-    	{
-    		return Create (job_type, job_options, DateTime.Now, JobPriority.Lowest, false);
-    	}
-    
-    	public Job CreatePersistent (Type job_type, string job_options)
-    	{
-    		return Create (job_type, job_options, DateTime.Now, JobPriority.Lowest, true);
-    	}
-    
-    	internal Job Create (Type job_type, string job_options, DateTime run_at, JobPriority job_priority, bool persistent)
-    	{
+	public class JobStore : DbStore<Job>
+	{
+		internal static void CreateTable (FSpotDatabaseConnection database)
+		{
+			if (database.TableExists ("jobs")) {
+				return;
+			}
+
+			database.Execute (
+				"CREATE TABLE jobs (\n" +
+				"  id           INTEGER PRIMARY KEY NOT NULL, \n" +
+				"  job_type     TEXT NOT NULL, \n" +
+				"  job_options  TEXT NOT NULL, \n" +
+				"  run_at       INTEGER, \n" +
+				"  job_priority INTEGER NOT NULL\n" +
+				")");
+		}
+
+		private Job LoadItem (Hyena.Data.Sqlite.IDataReader reader)
+		{
+			return (Job)Activator.CreateInstance (
+					Type.GetType (reader ["job_type"].ToString ()),
+					Db,
+					Convert.ToUInt32 (reader ["id"]),
+					reader ["job_options"].ToString (),
+					Convert.ToInt32 (reader ["run_at"]),
+					(JobPriority)Convert.ToInt32 (reader ["job_priority"]),
+					true);
+		}
+
+		private void LoadAllItems ()
+		{
+			Hyena.Data.Sqlite.IDataReader reader = Database.Query ("SELECT id, job_type, job_options, run_at, job_priority FROM jobs");
+
+			Scheduler.Suspend ();
+			while (reader.Read ()) {
+				Job job = LoadItem (reader);
+				AddToCache (job);
+				job.Finished += HandleRemoveJob;
+				Scheduler.Schedule (job, job.JobPriority);
+				job.Status = JobStatus.Scheduled;
+			}
+
+			reader.Dispose ();
+		}
+
+		public Job Create (Type job_type, string job_options)
+		{
+			return Create (job_type, job_options, DateTime.Now, JobPriority.Lowest, false);
+		}
+
+		public Job CreatePersistent (Type job_type, string job_options)
+		{
+			return Create (job_type, job_options, DateTime.Now, JobPriority.Lowest, true);
+		}
+
+		internal Job Create (Type job_type, string job_options, DateTime run_at, JobPriority job_priority, bool persistent)
+		{
 			long id = 0;
-    		if (persistent)
-    			id = Database.Execute (new HyenaSqliteCommand ("INSERT INTO jobs (job_type, job_options, run_at, job_priority) VALUES (?, ?, ?, ?)",
-    						job_type.ToString (),
-    						job_options,
-    						DateTimeUtil.FromDateTime (run_at),
-    						Convert.ToInt32 (job_priority)));
-    
-			Job job = (Job)Activator.CreateInstance (job_type, Db, (uint) id, job_options, run_at, job_priority, true);
-    
-    		AddToCache (job);
-    		job.Finished += HandleRemoveJob;
-    		Scheduler.Schedule (job, job.JobPriority);
-    		job.Status = JobStatus.Scheduled;
-    		EmitAdded (job);
-    
-    		return job;
-    	}
-    
-    	public override void Commit (Job item)
-    	{
-    		if (item.Persistent)
-    			Database.Execute(new HyenaSqliteCommand("UPDATE jobs " 					+
-    									"SET job_type = ? "		+
-    									"SET job_options = ? "	+
-    									"SET run_at = ? "			+
-    									"SET job_priority = ? "	+
-    									"WHERE id = ?",
-    									"Empty", //FIXME
-    									item.JobOptions,
-    									DateTimeUtil.FromDateTime (item.RunAt),
-    									item.JobPriority,
-    									item.Id));
-    
-    		EmitChanged (item);
-    	}
-    
-    	public override Job Get (uint id)
-    	{
-                // we never use this
-                return null;
-    	}
-    
-    	public override void Remove (Job item)
-    	{
-    		RemoveFromCache (item);
-    
-    		if (item.Persistent)
-    			Database.Execute (new HyenaSqliteCommand ("DELETE FROM jobs WHERE id = ?", item.Id));
-    
-    		EmitRemoved (item);
-    	}
-    
-    	public void HandleRemoveJob (Object o, EventArgs e)
-    	{
-    		Remove (o as Job);
-    	}
-    
+			if (persistent)
+				id = Database.Execute (new HyenaSqliteCommand ("INSERT INTO jobs (job_type, job_options, run_at, job_priority) VALUES (?, ?, ?, ?)",
+							job_type.ToString (),
+							job_options,
+							DateTimeUtil.FromDateTime (run_at),
+							Convert.ToInt32 (job_priority)));
+
+			Job job = (Job)Activator.CreateInstance (job_type, Db, (uint)id, job_options, run_at, job_priority, true);
+
+			AddToCache (job);
+			job.Finished += HandleRemoveJob;
+			Scheduler.Schedule (job, job.JobPriority);
+			job.Status = JobStatus.Scheduled;
+			EmitAdded (job);
+
+			return job;
+		}
+
+		public override void Commit (Job item)
+		{
+			if (item.Persistent)
+				Database.Execute (new HyenaSqliteCommand (
+					"UPDATE jobs " +
+					"  SET job_type = ? " +
+					"  SET job_options = ? " +
+					"  SET run_at = ? " +
+					"  SET job_priority = ? " +
+					"  WHERE id = ?",
+					"Empty", //FIXME
+					item.JobOptions,
+					DateTimeUtil.FromDateTime (item.RunAt),
+					item.JobPriority,
+					item.Id));
+
+			EmitChanged (item);
+		}
+
+		public override Job Get (uint id)
+		{
+			// we never use this
+			return null;
+		}
+
+		public override void Remove (Job item)
+		{
+			RemoveFromCache (item);
+
+			if (item.Persistent)
+				Database.Execute (new HyenaSqliteCommand ("DELETE FROM jobs WHERE id = ?", item.Id));
+
+			EmitRemoved (item);
+		}
+
+		public void HandleRemoveJob (Object o, EventArgs e)
+		{
+			Remove (o as Job);
+		}
+
 		public JobStore (IDb db, bool is_new) : base (db, true)
-    	{
-    		if (is_new || !Database.TableExists ("jobs")) {
-    			CreateTable (Database);
-    		} else {
-    			LoadAllItems ();
-            }
-    	}
-    }
+		{
+			if (is_new || !Database.TableExists ("jobs")) {
+				CreateTable (Database);
+			} else {
+				LoadAllItems ();
+			}
+		}
+	}
 }

--- a/src/Core/FSpot.Database/Jobs/CalculateHashJob.cs
+++ b/src/Core/FSpot.Database/Jobs/CalculateHashJob.cs
@@ -37,11 +37,6 @@ namespace FSpot.Database.Jobs
 {
 	public class CalculateHashJob : Job
 	{
-		public CalculateHashJob (IDb db, uint id, string job_options, int run_at, JobPriority job_priority, bool persistent)
-			: this (db, id, job_options, DateTimeUtil.ToDateTime (run_at), job_priority, persistent)
-		{
-		}
-
 		public CalculateHashJob (IDb db, uint id, string job_options, DateTime run_at, JobPriority job_priority, bool persistent)
 			: base (db, id, job_options, job_priority, run_at, persistent)
 		{

--- a/src/Core/FSpot.Database/Jobs/CalculateHashJob.cs
+++ b/src/Core/FSpot.Database/Jobs/CalculateHashJob.cs
@@ -30,14 +30,11 @@
 //
 
 using System;
-
 using Banshee.Kernel;
-
-using FSpot.Database;
-
 using Hyena;
 
-namespace FSpot.Database.Jobs {
+namespace FSpot.Database.Jobs
+{
 	public class CalculateHashJob : Job
 	{
 		public CalculateHashJob (IDb db, uint id, string job_options, int run_at, JobPriority job_priority, bool persistent)
@@ -52,7 +49,7 @@ namespace FSpot.Database.Jobs {
 
 		public static CalculateHashJob Create (JobStore job_store, uint photo_id)
 		{
-			return (CalculateHashJob) job_store.CreatePersistent (typeof(CalculateHashJob), photo_id.ToString ());
+			return (CalculateHashJob)job_store.CreatePersistent (typeof (CalculateHashJob), photo_id.ToString ());
 		}
 
 		protected override bool Execute ()

--- a/src/Core/FSpot.Database/Jobs/CalculateHashJob.cs
+++ b/src/Core/FSpot.Database/Jobs/CalculateHashJob.cs
@@ -44,8 +44,10 @@ namespace FSpot.Database.Jobs
 
 		public static CalculateHashJob Create (JobStore job_store, uint photo_id)
 		{
-			return (CalculateHashJob)job_store.CreatePersistent (typeof (CalculateHashJob), photo_id.ToString ());
+			return (CalculateHashJob)job_store.CreatePersistent (JobName, photo_id.ToString ());
 		}
+
+		public static string JobName => "CalculateHash";
 
 		protected override bool Execute ()
 		{

--- a/src/Core/FSpot.Database/Jobs/Job.cs
+++ b/src/Core/FSpot.Database/Jobs/Job.cs
@@ -47,8 +47,8 @@ namespace FSpot.Database.Jobs
 			Db = db;
 		}
 
-		public string JobOptions { get; set; }
-		internal JobPriority JobPriority { get; set; }
+		public string JobOptions { get; private set; }
+		internal JobPriority JobPriority { get; private set; }
 		//Not in use yet !
 		public DateTime RunAt { get; private set; }
 		public bool Persistent { get; private set; }

--- a/src/Core/FSpot.Database/Jobs/Job.cs
+++ b/src/Core/FSpot.Database/Jobs/Job.cs
@@ -38,12 +38,12 @@ namespace FSpot.Database.Jobs
 {
 	public abstract class Job : DbItem, IJob
 	{
-		public Job (IDb db, uint id, string job_options, JobPriority job_priority, DateTime run_at, bool persistent) : base (id)
+		public Job (IDb db, JobData jobData) : base (jobData.Id)
 		{
-			JobOptions = job_options;
-			JobPriority = job_priority;
-			RunAt = run_at;
-			Persistent = persistent;
+			JobOptions = jobData.JobOptions;
+			JobPriority = jobData.JobPriority;
+			RunAt = jobData.RunAt;
+			Persistent = jobData.Persistent;
 			Db = db;
 		}
 

--- a/src/Core/FSpot.Database/Jobs/Job.cs
+++ b/src/Core/FSpot.Database/Jobs/Job.cs
@@ -1,0 +1,87 @@
+//
+// Job.cs
+//
+// Author:
+//   Mike Gemünde <mike@gemuende.de>
+//   Stephane Delcroix <sdelcroix@src.gnome.org>
+//
+// Copyright (C) 2007-2010 Novell, Inc.
+// Copyright (C) 2010 Mike Gemünde
+// Copyright (C) 2007-2008 Stephane Delcroix
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using Banshee.Kernel;
+using FSpot.Core;
+using FSpot.Jobs;
+
+namespace FSpot.Database.Jobs
+{
+	public abstract class Job : DbItem, IJob
+	{
+		public Job (IDb db, uint id, string job_options, JobPriority job_priority, DateTime run_at, bool persistent) : base (id)
+		{
+			JobOptions = job_options;
+			JobPriority = job_priority;
+			RunAt = run_at;
+			Persistent = persistent;
+			Db = db;
+		}
+
+		public string JobOptions { get; set; }
+		internal JobPriority JobPriority { get; set; }
+		//Not in use yet !
+		public DateTime RunAt { get; private set; }
+		public bool Persistent { get; private set; }
+		protected IDb Db { get; private set; }
+
+		public event EventHandler Finished;
+
+		private JobStatus status;
+		public JobStatus Status {
+			get { return status; }
+			set {
+				status = value;
+				switch (value) {
+				case JobStatus.Finished:
+				case JobStatus.Failed:
+					if (Finished != null)
+						Finished (this, new EventArgs ());
+					break;
+				default:
+					break;
+				}
+			}
+		}
+
+		public void Run ()
+		{
+			Status = JobStatus.Running;
+			if (Execute ())
+				Status = JobStatus.Finished;
+			else
+				Status = JobStatus.Failed;
+		}
+
+		protected abstract bool Execute ();
+	}
+}

--- a/src/Core/FSpot.Database/Jobs/JobData.cs
+++ b/src/Core/FSpot.Database/Jobs/JobData.cs
@@ -1,13 +1,10 @@
 //
-// CalculateHashJob.cs
+// Job.cs
 //
 // Author:
-//   Thomas Van Machelen <thomasvm@src.gnome.org>
-//   Ruben Vermeersch <ruben@savanne.be>
+//   Daniel Köb <dkoeb@peony.at>
 //
-// Copyright (C) 2008-2010 Novell, Inc.
-// Copyright (C) 2008 Thomas Van Machelen
-// Copyright (C) 2008, 2010 Ruben Vermeersch
+// Copyright (C) 2018 Daniel Köb
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -31,38 +28,16 @@
 
 using System;
 using Banshee.Kernel;
-using Hyena;
 
 namespace FSpot.Database.Jobs
 {
-	public class CalculateHashJob : Job
+	public class JobData
 	{
-		public CalculateHashJob (IDb db, JobData jobData)
-			: base (db, jobData)
-		{
-		}
-
-		public static CalculateHashJob Create (JobStore job_store, uint photo_id)
-		{
-			return (CalculateHashJob)job_store.CreatePersistent (typeof (CalculateHashJob), photo_id.ToString ());
-		}
-
-		protected override bool Execute ()
-		{
-			//this will add some more reactivity to the system
-			System.Threading.Thread.Sleep (200);
-
-			uint photo_id = Convert.ToUInt32 (JobOptions);
-			Log.DebugFormat ("Calculating Hash {0}...", photo_id);
-
-			try {
-				Photo photo = Db.Photos.Get (Convert.ToUInt32 (photo_id));
-				Db.Photos.CalculateMD5Sum (photo);
-				return true;
-			} catch (System.Exception e) {
-				Log.DebugFormat ("Error Calculating Hash for photo {0}: {1}", JobOptions, e.Message);
-			}
-			return false;
-		}
+		public IDb Db { get; set; }
+		public uint Id { get; set; }
+		public string JobOptions { get; set; }
+		public JobPriority JobPriority { get; set; }
+		public DateTime RunAt { get; set; }
+		public bool Persistent { get; set; }
 	}
 }

--- a/src/Core/FSpot.Database/Jobs/SyncMetadataJob.cs
+++ b/src/Core/FSpot.Database/Jobs/SyncMetadataJob.cs
@@ -40,11 +40,6 @@ namespace FSpot.Database.Jobs
 {
 	public class SyncMetadataJob : Job
 	{
-		public SyncMetadataJob (IDb db, uint id, string job_options, int run_at, JobPriority job_priority, bool persistent)
-			: this (db, id, job_options, DateTimeUtil.ToDateTime (run_at), job_priority, persistent)
-		{
-		}
-
 		public SyncMetadataJob (IDb db, uint id, string job_options, DateTime run_at, JobPriority job_priority, bool persistent)
 			: base (db, id, job_options, job_priority, run_at, persistent)
 		{

--- a/src/Core/FSpot.Database/Jobs/SyncMetadataJob.cs
+++ b/src/Core/FSpot.Database/Jobs/SyncMetadataJob.cs
@@ -40,8 +40,8 @@ namespace FSpot.Database.Jobs
 {
 	public class SyncMetadataJob : Job
 	{
-		public SyncMetadataJob (IDb db, uint id, string job_options, DateTime run_at, JobPriority job_priority, bool persistent)
-			: base (db, id, job_options, job_priority, run_at, persistent)
+		public SyncMetadataJob (IDb db, JobData jobData)
+			: base (db, jobData)
 		{
 		}
 

--- a/src/Core/FSpot.Database/Jobs/SyncMetadataJob.cs
+++ b/src/Core/FSpot.Database/Jobs/SyncMetadataJob.cs
@@ -48,8 +48,10 @@ namespace FSpot.Database.Jobs
 		//Use THIS static method to create a job...
 		public static SyncMetadataJob Create (JobStore job_store, Photo photo)
 		{
-			return (SyncMetadataJob)job_store.CreatePersistent (typeof (SyncMetadataJob), photo.Id.ToString ());
+			return (SyncMetadataJob)job_store.CreatePersistent (JobName, photo.Id.ToString ());
 		}
+
+		public static string JobName => "SyncMetadata";
 
 		protected override bool Execute ()
 		{

--- a/src/Core/FSpot.Database/Jobs/SyncMetadataJob.cs
+++ b/src/Core/FSpot.Database/Jobs/SyncMetadataJob.cs
@@ -30,74 +30,73 @@
 //
 
 using System;
-
 using Banshee.Kernel;
-
-using Hyena;
-
 using FSpot.Core;
-using FSpot.Database;
 using FSpot.Settings;
 using FSpot.Utils;
+using Hyena;
 
-namespace FSpot.Database.Jobs {
-    public class SyncMetadataJob : Job
-    {
-        public SyncMetadataJob (IDb db, uint id, string job_options, int run_at, JobPriority job_priority, bool persistent) : this (db, id, job_options, DateTimeUtil.ToDateTime (run_at), job_priority, persistent)
-        {
-        }
+namespace FSpot.Database.Jobs
+{
+	public class SyncMetadataJob : Job
+	{
+		public SyncMetadataJob (IDb db, uint id, string job_options, int run_at, JobPriority job_priority, bool persistent)
+			: this (db, id, job_options, DateTimeUtil.ToDateTime (run_at), job_priority, persistent)
+		{
+		}
 
-        public SyncMetadataJob (IDb db, uint id, string job_options, DateTime run_at, JobPriority job_priority, bool persistent) : base (db, id, job_options, job_priority, run_at, persistent)
-        {
-        }
+		public SyncMetadataJob (IDb db, uint id, string job_options, DateTime run_at, JobPriority job_priority, bool persistent)
+			: base (db, id, job_options, job_priority, run_at, persistent)
+		{
+		}
 
-        //Use THIS static method to create a job...
-        public static SyncMetadataJob Create (JobStore job_store, Photo photo)
-        {
-            return (SyncMetadataJob) job_store.CreatePersistent (typeof (SyncMetadataJob), photo.Id.ToString ());
-        }
+		//Use THIS static method to create a job...
+		public static SyncMetadataJob Create (JobStore job_store, Photo photo)
+		{
+			return (SyncMetadataJob)job_store.CreatePersistent (typeof (SyncMetadataJob), photo.Id.ToString ());
+		}
 
-        protected override bool Execute ()
-        {
-            //this will add some more reactivity to the system
-            System.Threading.Thread.Sleep (500);
+		protected override bool Execute ()
+		{
+			//this will add some more reactivity to the system
+			System.Threading.Thread.Sleep (500);
 
-            try {
-                Photo photo = Db.Photos.Get (Convert.ToUInt32 (JobOptions));
-                if (photo == null)
-                    return false;
+			try {
+				Photo photo = Db.Photos.Get (Convert.ToUInt32 (JobOptions));
+				if (photo == null)
+					return false;
 
-                Log.DebugFormat ("Syncing metadata to file ({0})...", photo.DefaultVersion.Uri);
+				Log.DebugFormat ("Syncing metadata to file ({0})...", photo.DefaultVersion.Uri);
 
-                WriteMetadataToImage (photo);
-                return true;
-            } catch (System.Exception e) {
-                Log.ErrorFormat ("Error syncing metadata to file\n{0}", e);
-            }
-            return false;
-        }
+				WriteMetadataToImage (photo);
+				return true;
+			} catch (System.Exception e) {
+				Log.ErrorFormat ("Error syncing metadata to file\n{0}", e);
+			}
+			return false;
+		}
 
-        void WriteMetadataToImage (Photo photo)
-        {
-            Tag [] tags = photo.Tags;
-            string [] names = new string [tags.Length];
+		void WriteMetadataToImage (Photo photo)
+		{
+			Tag [] tags = photo.Tags;
+			string [] names = new string [tags.Length];
 
-            for (int i = 0; i < tags.Length; i++)
-                names [i] = tags [i].Name;
+			for (int i = 0; i < tags.Length; i++)
+				names [i] = tags [i].Name;
 
-            using (var metadata = Metadata.Parse (photo.DefaultVersion.Uri)) {
-                metadata.EnsureAvailableTags ();
+			using (var metadata = Metadata.Parse (photo.DefaultVersion.Uri)) {
+				metadata.EnsureAvailableTags ();
 
-                var tag = metadata.ImageTag;
-                tag.DateTime = photo.Time;
-                tag.Comment = photo.Description ?? string.Empty;
-                tag.Keywords = names;
-                tag.Rating = photo.Rating;
-                tag.Software = Defines.PACKAGE + " version " + Defines.VERSION;
+				var tag = metadata.ImageTag;
+				tag.DateTime = photo.Time;
+				tag.Comment = photo.Description ?? string.Empty;
+				tag.Keywords = names;
+				tag.Rating = photo.Rating;
+				tag.Software = Defines.PACKAGE + " version " + Defines.VERSION;
 
-                var always_sidecar = Preferences.Get<bool> (Preferences.METADATA_ALWAYS_USE_SIDECAR);
-                metadata.SaveSafely (photo.DefaultVersion.Uri, always_sidecar);
-            }
-        }
-    }
+				var always_sidecar = Preferences.Get<bool> (Preferences.METADATA_ALWAYS_USE_SIDECAR);
+				metadata.SaveSafely (photo.DefaultVersion.Uri, always_sidecar);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Add support for refactoring safe job type names as well as legacy job type names stored in the database.
Also includes some code cleanup and simplifications but no tests as JobStore is not (yet) testable...